### PR TITLE
chore: Harmonize imports of sqlalchemy module, use `sa` where applicable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,6 +218,12 @@ extend-ignore = [
 extend-exclude = [
 ]
 
+[tool.ruff.lint.flake8-import-conventions]
+banned-from = ["typing"]
+
+[tool.ruff.lint.flake8-import-conventions.extend-aliases]
+typing = "t"
+
 [tool.ruff.per-file-ignores]
 "*/tests/*" = [
   "S101",  # Allow use of `assert`, and `print`.


### PR DESCRIPTION
## About

The patch follows a convention to import SQLAlchemy like `import sqlalchemy as sa`.

In this spirit, all references, even simple ones like symbols to SQLAlchemy base types like `TEXT`, or `BIGINT`, will be referenced by `sa.TEXT`, `sa.BIGINT`, etc., so it is easy to tell them apart when harmonizing type definitions coming from SA's built-in dialects vs. type definitions coming from 3rd-party dialects.

## References

- https://github.com/MeltanoLabs/target-postgres/pull/255
