### PR TITLE
Remove workaround for `_`-prefixed column names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 - Add support for container types `ARRAY`, `OBJECT`, and `FLOAT_VECTOR`.
 - Improve write operations to be closer to `target-postgres`.
 - Switch to new SQLAlchemy dialect for CrateDB.
+- Removed workaround for `_`-prefixed column names.
+  The package now requires CrateDB 6.2 or higher.
 
 ## 2023-12-08 v0.0.1
 - Make it work. It can run the canonical Meltano GitHub -> DB example.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ and loaders, and based on the [Meltano PostgreSQL target].
 In order to learn more about Singer, Meltano, and friends, navigate to the
 [Singer Intro](./docs/singer-intro.md).
 
+Operating the package successfully needs CrateDB 6.2 or higher.
 
 ## Install
 

--- a/target_cratedb/tests/test_standard_target.py
+++ b/target_cratedb/tests/test_standard_target.py
@@ -30,7 +30,7 @@ except ImportError:
     from importlib_resources import files as resource_files  # type: ignore[no-redef]
 
 
-METADATA_COLUMN_PREFIX = "__sdc"
+METADATA_COLUMN_PREFIX = "_sdc"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## About
With CrateDB 6.2, the workaround against `_`-prefixed column names is no longer needed. Thanks! 🌻

## References
- GH-53
- https://github.com/crate/crate/issues/15161
- https://github.com/crate/dlt-cratedb/pull/30
- https://github.com/crate/cratedb-fivetran-destination/pull/83

/cc @hammerhead, @surister, @kneth 