### PR TITLE
Add pre-flight check for CrateDB >= 6.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@
 name: "Tests"
 
 on:
-  pull_request: ~
+  pull_request:
   push:
     branches: [ main ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ dependencies = [
   "importlib-resources; python_version<'3.9'",                                                                    # "meltanolabs-target-postgres==0.0.9",
   "meltanolabs-target-postgres @ git+https://github.com/singer-contrib/meltanolabs-target-postgres.git@pgvector",
   "sqlalchemy-cratedb[vector]",
+  "verlib2<0.4",
 ]
 optional-dependencies.all = [
   "meltano-target-cratedb[vector]",


### PR DESCRIPTION
## About
Implement the suggestion to add a pre-flight check about the CrateDB version, because newer releases will require CrateDB 6.2 or higher.

## References
- https://github.com/crate-workbench/meltano-target-cratedb/pull/57#pullrequestreview-3444366331
