### PR TITLE
Dependencies: Update to vanilla meltanolabs-target-postgres 0.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: [
           "3.10",
-          "3.12",
+          "3.14",
         ]
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: [
-          "3.9",
+          "3.10",
           "3.12",
         ]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,12 +31,12 @@ jobs:
           "3.10",
           "3.12",
         ]
-
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
-      # Do not tear down Testcontainers
-      TC_KEEPALIVE: true
+      TC_KEEPALIVE: true  # Do not tear down Testcontainers
+      UV_PYTHON_DOWNLOADS: never
+      UV_SYSTEM_PYTHON: true
 
     # https://docs.github.com/en/actions/using-containerized-services/about-service-containers
     services:
@@ -56,19 +56,19 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: x64
-        cache: 'pip'
-        cache-dependency-path: 'pyproject.toml'
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        cache-dependency-glob: |
+          pyproject.toml
+        cache-suffix: ${{ matrix.python-version }}
+        enable-cache: true
+        version: "latest"
 
     - name: Set up project
       run: |
-
-        # `setuptools 0.64.0` adds support for editable install hooks (PEP 660).
-        # https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6400
-        pip install "setuptools>=64" --upgrade
-
-        # Install package in editable mode.
-        pip install --use-pep517 --prefer-binary --editable=.[all,develop,test]
+        uv pip install --editable='.[all,develop,test]'
 
     - name: Run linter and software tests
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .venv*
 *.egg-info
 .coverage*
+.http_cache
 coverage.xml
 build
 dist

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Switch to new SQLAlchemy dialect for CrateDB.
 - Removed workaround for `_`-prefixed column names.
   The package now requires CrateDB 6.2 or higher.
+- Dependencies: Updated to vanilla meltanolabs-target-postgres 0.6
 
 ## 2023-12-08 v0.0.1
 - Make it work. It can run the canonical Meltano GitHub -> DB example.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ license = { text = "MIT" }
 authors = [
   { name = "Andreas Motl", email = "andreas.motl@crate.io" },
 ]
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",
@@ -58,6 +58,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: SQL",
   "Topic :: Adaptive Technologies",
   "Topic :: Communications",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,8 +131,8 @@ scripts.target-cratedb = "target_cratedb.target:TargetCrateDB.cli"
 namespaces = false
 
 [tool.uv.sources]
-meltano-tap-countries = { git = "https://github.com/meltano/sdk.git", subdirectory = "packages/meltano-tap-countries", rev = "main" }
-meltano-tap-fundamentals = { git = "https://github.com/meltano/sdk.git", subdirectory = "packages/meltano-tap-fundamentals", rev = "main" }
+meltano-tap-countries = { git = "https://github.com/meltano/sdk.git", subdirectory = "packages/meltano-tap-countries", rev = "ef455bb" }
+meltano-tap-fundamentals = { git = "https://github.com/meltano/sdk.git", subdirectory = "packages/meltano-tap-fundamentals", rev = "ef455bb" }
 
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ license = { text = "MIT" }
 authors = [
   { name = "Andreas Motl", email = "andreas.motl@crate.io" },
 ]
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.10,<3.13"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",
@@ -55,8 +55,6 @@ classifiers = [
   "Operating System :: Unix",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -90,8 +88,8 @@ dynamic = [
 ]
 dependencies = [
   "cratedb-toolkit",
-  "importlib-resources; python_version<'3.9'",                                                                    # "meltanolabs-target-postgres==0.0.9",
-  "meltanolabs-target-postgres @ git+https://github.com/singer-contrib/meltanolabs-target-postgres.git@pgvector",
+  "importlib-resources; python_version<'3.9'", # "meltanolabs-target-postgres==0.0.9",
+  "meltanolabs-target-postgres>=0.6,<0.7",
   "sqlalchemy-cratedb[vector]",
   "verlib2<0.4",
 ]
@@ -114,10 +112,13 @@ optional-dependencies.test = [
   "pytest<9",
   "pytest-cov<8",
   "pytest-mock<4",
+  "tap-countries",
+  "tap-fundamentals",
 ]
-optional-dependencies.vector = [
-  "numpy",
-]
+# optional-dependencies.vector = [
+#   "meltanolabs-target-postgres @ git+https://github.com/singer-contrib/meltanolabs-target-postgres.git@pgvector",
+#   "sqlalchemy-cratedb[vector]",
+# ]
 urls.changelog = "https://github.com/crate-workbench/meltano-target-cratedb/blob/main/CHANGES.md"
 urls.documentation = "https://github.com/crate-workbench/meltano-target-cratedb"
 urls.homepage = "https://github.com/crate-workbench/meltano-target-cratedb"
@@ -126,6 +127,10 @@ scripts.target-cratedb = "target_cratedb.target:TargetCrateDB.cli"
 
 [tool.setuptools.packages.find]
 namespaces = false
+
+[tool.uv.sources]
+tap-countries = { git = "https://github.com/meltano/sdk.git", subdirectory = "packages/tap-countries", rev = "main" }
+tap-fundamentals = { git = "https://github.com/meltano/sdk.git", subdirectory = "packages/tap-fundamentals", rev = "main" }
 
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,11 +111,11 @@ optional-dependencies.release = [
   "twine<7",
 ]
 optional-dependencies.test = [
+  "meltano-tap-countries",
+  "meltano-tap-fundamentals",
   "pytest<9",
   "pytest-cov<8",
   "pytest-mock<4",
-  "tap-countries",
-  "tap-fundamentals",
 ]
 # optional-dependencies.vector = [
 #   "meltanolabs-target-postgres @ git+https://github.com/singer-contrib/meltanolabs-target-postgres.git@pgvector",
@@ -131,8 +131,8 @@ scripts.target-cratedb = "target_cratedb.target:TargetCrateDB.cli"
 namespaces = false
 
 [tool.uv.sources]
-tap-countries = { git = "https://github.com/meltano/sdk.git", subdirectory = "packages/tap-countries", rev = "main" }
-tap-fundamentals = { git = "https://github.com/meltano/sdk.git", subdirectory = "packages/tap-fundamentals", rev = "main" }
+meltano-tap-countries = { git = "https://github.com/meltano/sdk.git", subdirectory = "packages/meltano-tap-countries", rev = "main" }
+meltano-tap-fundamentals = { git = "https://github.com/meltano/sdk.git", subdirectory = "packages/meltano-tap-fundamentals", rev = "main" }
 
 [tool.black]
 line-length = 120

--- a/target_cratedb/sinks.py
+++ b/target_cratedb/sinks.py
@@ -301,7 +301,7 @@ class CrateDBSink(PostgresSink):
         """
         with self.connector._connect() as connection:
             if isinstance(table, FullyQualifiedName):
-                table_full = str(table)
+                table_full = f'"{table.schema}"."{table.table}"'
             elif isinstance(table, sa.Table):
                 table_full = f'"{table.schema}"."{table.name}"'
             elif isinstance(table, str):

--- a/target_cratedb/tests/data_files/array_boolean.singer
+++ b/target_cratedb/tests/data_files/array_boolean.singer
@@ -1,0 +1,5 @@
+{"type": "SCHEMA", "stream": "array_boolean", "key_properties": ["id"], "schema": {"required": ["id"], "type": "object", "properties": {"id": {"type": "integer"}, "value": {"type": "array", "items": {"type": "boolean"}}}}}
+{"type": "RECORD", "stream": "array_boolean", "record": {"id": 1, "value": [ true, false ]}}
+{"type": "RECORD", "stream": "array_boolean", "record": {"id": 2, "value": [ false ]}}
+{"type": "RECORD", "stream": "array_boolean", "record": {"id": 3, "value": [ false, true, true, false ]}}
+{"type": "STATE", "value": {"array_boolean": 3}}

--- a/target_cratedb/tests/data_files/array_float_vector.singer
+++ b/target_cratedb/tests/data_files/array_float_vector.singer
@@ -1,0 +1,5 @@
+{"type": "SCHEMA", "stream": "array_float_vector", "key_properties": ["id"], "schema": {"required": ["id"], "type": "object", "properties": {"id": {"type": "integer"}, "value": {"type": "array", "items": {"type": "number"}, "additionalProperties": {"storage": {"type": "vector", "dim": 4}}}}}}
+{"type": "RECORD", "stream": "array_float_vector", "record": {"id": 1, "value": [ 1.1, 2.1, 1.1, 1.3 ]}}
+{"type": "RECORD", "stream": "array_float_vector", "record": {"id": 2, "value": [ 1.0, 1.0, 1.0, 2.3 ]}}
+{"type": "RECORD", "stream": "array_float_vector", "record": {"id": 3, "value": [ 2.0, 1.2, 1.0, 0.9 ]}}
+{"type": "STATE", "value": {"array_float_vector": 3}}

--- a/target_cratedb/tests/data_files/array_number.singer
+++ b/target_cratedb/tests/data_files/array_number.singer
@@ -1,0 +1,5 @@
+{"type": "SCHEMA", "stream": "array_number", "key_properties": ["id"], "schema": {"required": ["id"], "type": "object", "properties": {"id": {"type": "integer"}, "value": {"type": "array", "items": {"type": "number"}}}}}
+{"type": "RECORD", "stream": "array_number", "record": {"id": 1, "value": [ 42.42, 84.84, 23 ]}}
+{"type": "RECORD", "stream": "array_number", "record": {"id": 2, "value": [ 1.0 ]}}
+{"type": "RECORD", "stream": "array_number", "record": {"id": 3, "value": [ 1.11, 2.22, 3, 4, 5.55 ]}}
+{"type": "STATE", "value": {"array_number": 3}}

--- a/target_cratedb/tests/data_files/array_string.singer
+++ b/target_cratedb/tests/data_files/array_string.singer
@@ -1,0 +1,6 @@
+{"type": "SCHEMA", "stream": "array_string", "key_properties": ["id"], "schema": {"required": ["id"], "type": "object", "properties": {"id": {"type": "integer"}, "value": {"type": "array","items": {"type": "string"}}}}}
+{"type": "RECORD", "stream": "array_string", "record": {"id": 1, "value": [ "apple", "orange", "pear" ]}}
+{"type": "RECORD", "stream": "array_string", "record": {"id": 2, "value": [ "banana", "apple" ]}}
+{"type": "RECORD", "stream": "array_string", "record": {"id": 3, "value": [ "pear" ]}}
+{"type": "RECORD", "stream": "array_string", "record": {"id": 4, "value": [ "orange", "banana", "apple", "pear" ]}}
+{"type": "STATE", "value": {"array_string": 4}}

--- a/target_cratedb/tests/data_files/array_timestamp.singer
+++ b/target_cratedb/tests/data_files/array_timestamp.singer
@@ -1,0 +1,5 @@
+{"type": "SCHEMA", "stream": "array_timestamp", "key_properties": ["id"], "schema": {"required": ["id"], "type": "object", "properties": {"id": {"type": "integer"}, "value": {"type": "array", "items": {"type": "string", "format": "date-time"}}}}}
+{"type": "RECORD", "stream": "array_timestamp", "record": {"id": 1, "value": [ "2023-12-13T01:15:02", "2023-12-13T01:16:02" ]}}
+{"type": "RECORD", "stream": "array_timestamp", "record": {"id": 2, "value": [ "2023-12-13T01:15:02" ]}}
+{"type": "RECORD", "stream": "array_timestamp", "record": {"id": 3, "value": [ "2023-12-13T01:15:02", "2023-12-13T01:16:02", "2023-12-13T01:17:02" ]}}
+{"type": "STATE", "value": {"array_timestamp": 3}}

--- a/target_cratedb/tests/data_files/object_mixed.singer
+++ b/target_cratedb/tests/data_files/object_mixed.singer
@@ -1,0 +1,3 @@
+{"type": "SCHEMA", "stream": "object_mixed", "key_properties": ["id"], "schema": {"required": ["id"], "type": "object", "properties": {"id": {"type": "integer"}, "value": {"type": "object"}}}}
+{"type": "RECORD", "stream": "object_mixed", "record": {"id": 1, "value": {"string": "foo", "integer": 42, "float": 42.42, "timestamp": "2023-12-13T01:15:02", "array_boolean": [true, false], "array_float": [42.42, 84.84], "array_integer": [42, 84], "array_string": ["foo", "bar"], "nested_object": {"foo": "bar"}}}}
+{"type": "STATE", "value": {"object_mixed": 1}}

--- a/target_cratedb/tests/test_standard_target.py
+++ b/target_cratedb/tests/test_standard_target.py
@@ -6,18 +6,15 @@ import copy
 import io
 from contextlib import redirect_stdout
 
-import jsonschema
 import pytest
 import sqlalchemy as sa
-from singer_sdk.exceptions import MissingKeyPropertiesError
+from singer_sdk.exceptions import InvalidRecord, MissingKeyPropertiesError
 from singer_sdk.testing import sync_end_to_end
 from sqlalchemy_cratedb.type import FloatVector
 from sqlalchemy_cratedb.type.object import ObjectTypeImpl
-from target_postgres.tests.samples.aapl.aapl import Fundamentals
-from target_postgres.tests.samples.sample_tap_countries.countries_tap import (
-    SampleTapCountries,
-)
-from target_postgres.tests.test_target_postgres import AssertionHelper
+from tap_countries.tap import TapCountries
+from tap_fundamentals import Fundamentals
+from target_postgres.tests.test_target_postgres import verify_data
 
 from target_cratedb.connector import CrateDBConnector
 from target_cratedb.sinks import MELTANO_CRATEDB_STRATEGY_DIRECT
@@ -120,11 +117,6 @@ def initialize_database(cratedb_config):
         conn.exec_driver_sql("CREATE TABLE IF NOT EXISTS melty.foo (a INT);")
 
 
-@pytest.fixture
-def helper(cratedb_target) -> AssertionHelper:
-    return AssertionHelper(target=cratedb_target, metadata_column_prefix=METADATA_COLUMN_PREFIX)
-
-
 def singer_file_to_target(file_name, target) -> None:
     """Singer file to Target, emulates a tap run
 
@@ -153,6 +145,42 @@ def singer_file_to_target(file_name, target) -> None:
     target.listen(buf)
 
 
+def verify_schema(
+    target: TargetCrateDB,
+    table_name: str,
+    check_columns: dict = None,
+):
+    """Checks whether the schema of a database table matches the provided column definitions.
+
+    Args:
+        target: The target to obtain a database connection from.
+        table_name: The schema and table name of the table to check data for.
+        check_columns: A dictionary mapping column names to their definitions. Currently,
+            it is all about the `type` attribute which is compared.
+        metadata_column_prefix: The prefix string for metadata columns. Usually `_sdc`.
+    """
+    check_columns = check_columns or {}
+    engine = create_engine(target)
+    schema = target.config["default_target_schema"]
+    with engine.connect() as connection:
+        meta = sa.MetaData()
+        table = sa.Table(table_name, meta, schema=schema, autoload_with=connection)
+        for column in table.c:
+            # Ignore `_sdc` metadata columns when verifying table schema.
+            if column.name.startswith(METADATA_COLUMN_PREFIX):
+                continue
+            try:
+                column_type_expected = check_columns[column.name]["type"]
+            except KeyError as ex:
+                raise ValueError(f"Invalid check_columns - missing definition for column: {column.name}") from ex
+            if not isinstance(column.type, column_type_expected):
+                raise TypeError(
+                    f"Column '{column.name}' (with type '{column.type}') "
+                    f"does not match expected type: {column_type_expected}"
+                )
+    engine.dispose()
+
+
 # TODO should set schemas for each tap individually so we don't collide
 
 
@@ -169,7 +197,7 @@ def test_sqlalchemy_url_config(cratedb_config):
     port = cratedb_config["port"]
 
     config = {"sqlalchemy_url": f"crate://{user}:{password}@{host}:{port}/{database}"}
-    tap = SampleTapCountries(config={}, state=None)
+    tap = TapCountries(config={}, state=None)
     target = TargetCrateDB(config=config)
     sync_end_to_end(tap, target)
 
@@ -225,7 +253,7 @@ def test_port_config():
 
 # Test name would work well
 def test_countries_to_cratedb(cratedb_config):
-    tap = SampleTapCountries(config={}, state=None)
+    tap = TapCountries(config={}, state=None)
     target = TargetCrateDB(config=cratedb_config)
     sync_end_to_end(tap, target)
 
@@ -252,9 +280,10 @@ def test_record_missing_key_property(cratedb_target):
 
 
 def test_record_missing_required_property(cratedb_target):
-    with pytest.raises(jsonschema.exceptions.ValidationError):
+    with pytest.raises(InvalidRecord) as e:
         file_name = "record_missing_required_property.singer"
         singer_file_to_target(file_name, cratedb_target)
+    assert "Record Message Validation Error: 'id' is a required property" in str(e.value)
 
 
 @pytest.mark.skipif(not MELTANO_CRATEDB_STRATEGY_DIRECT, reason="Does not work in temptable/upsert mode")
@@ -269,11 +298,11 @@ def test_special_chars_in_attributes(cratedb_target):
     singer_file_to_target(file_name, cratedb_target)
 
 
-def test_optional_attributes(cratedb_target, helper):
+def test_optional_attributes(cratedb_target):
     file_name = "optional_attributes.singer"
     singer_file_to_target(file_name, cratedb_target)
     row = {"id": 1, "optional": "This is optional"}
-    helper.verify_data("test_optional_attributes", 4, "id", row)
+    verify_data(cratedb_target, "test_optional_attributes", 4, "id", row)
 
 
 def test_schema_no_properties(cratedb_target):
@@ -282,7 +311,7 @@ def test_schema_no_properties(cratedb_target):
     singer_file_to_target(file_name, cratedb_target)
 
 
-def test_schema_updates(cratedb_target, helper):
+def test_schema_updates(cratedb_target):
     file_name = "schema_updates.singer"
     singer_file_to_target(file_name, cratedb_target)
     row = {
@@ -294,16 +323,16 @@ def test_schema_updates(cratedb_target, helper):
         "a5": None,
         "a6": None,
     }
-    helper.verify_data("test_schema_updates", 6, "id", row)
+    verify_data(cratedb_target, "test_schema_updates", 6, "id", row)
 
 
-def test_multiple_state_messages(cratedb_target, helper):
+def test_multiple_state_messages(cratedb_target):
     file_name = "multiple_state_messages.singer"
     singer_file_to_target(file_name, cratedb_target)
     row = {"id": 1, "metric": 100}
-    helper.verify_data("test_multiple_state_messages_a", 6, "id", row)
+    verify_data(cratedb_target, "test_multiple_state_messages_a", 6, "id", row)
     row = {"id": 1, "metric": 110}
-    helper.verify_data("test_multiple_state_messages_b", 6, "id", row)
+    verify_data(cratedb_target, "test_multiple_state_messages_b", 6, "id", row)
 
 
 # TODO test that data is correct
@@ -321,7 +350,7 @@ def test_multiple_schema_messages(cratedb_target, caplog):
 
 
 @pytest.mark.skip("ColumnValidationException[Validation failed for id: Updating a primary key is not supported]")
-def test_relational_data(cratedb_target, helper):
+def test_relational_data(cratedb_target):
     file_name = "user_location_data.singer"
     singer_file_to_target(file_name, cratedb_target)
 
@@ -378,12 +407,12 @@ def test_relational_data(cratedb_target, helper):
         },
     ]
 
-    helper.verify_data("test_users", 8, "id", users)
-    helper.verify_data("test_locations", 5, "id", locations)
-    helper.verify_data("test_user_in_location", 5, "id", user_in_location)
+    verify_data("test_users", 8, "id", users)
+    verify_data("test_locations", 5, "id", locations)
+    verify_data("test_user_in_location", 5, "id", user_in_location)
 
 
-def test_no_primary_keys(cratedb_target, helper):
+def test_no_primary_keys(cratedb_target):
     """We run both of these tests twice just to ensure that no records are removed and append only works properly"""
     engine = create_engine(cratedb_target)
     table_name = "test_no_pk"
@@ -403,7 +432,7 @@ def test_no_primary_keys(cratedb_target, helper):
     singer_file_to_target(file_name, cratedb_target)
 
     # Will populate 22 records, we run this twice.
-    helper.verify_data(table_name, 16)
+    verify_data(cratedb_target, table_name, 16)
 
 
 def test_no_type(cratedb_target):
@@ -411,19 +440,20 @@ def test_no_type(cratedb_target):
     singer_file_to_target(file_name, cratedb_target)
 
 
-def test_duplicate_records(cratedb_target, helper):
+def test_duplicate_records(cratedb_target):
     file_name = "duplicate_records.singer"
     singer_file_to_target(file_name, cratedb_target)
     row = {"id": 1, "metric": 100}
-    helper.verify_data("test_duplicate_records", 2, "id", row)
+    verify_data(cratedb_target, "test_duplicate_records", 2, "id", row)
 
 
-def test_array_boolean(cratedb_target, helper):
+def test_array_boolean(cratedb_target):
     file_name = "array_boolean.singer"
     singer_file_to_target(file_name, cratedb_target)
     row = {"id": 1, "value": [True, False]}
-    helper.verify_data("array_boolean", 3, "id", row)
-    helper.verify_schema(
+    verify_data(cratedb_target, "array_boolean", 3, "id", row)
+    verify_schema(
+        cratedb_target,
         "array_boolean",
         check_columns={
             "id": {"type": sa.BIGINT},
@@ -432,16 +462,18 @@ def test_array_boolean(cratedb_target, helper):
     )
 
 
+@pytest.mark.skip("pgvector patch did not land in upstream target-postgres yet")
 @pytest.mark.skipif(not MELTANO_CRATEDB_STRATEGY_DIRECT, reason="Does not work in temptable/upsert mode")
-def test_array_float_vector(cratedb_target, helper):
+def test_array_float_vector(cratedb_target):
     file_name = "array_float_vector.singer"
     singer_file_to_target(file_name, cratedb_target)
     row = {
         "id": 1,
         "value": [1.1, 2.1, 1.1, 1.3],
     }
-    helper.verify_data("array_float_vector", 3, "id", row)
-    helper.verify_schema(
+    verify_data(cratedb_target, "array_float_vector", 3, "id", row)
+    verify_schema(
+        cratedb_target,
         "array_float_vector",
         check_columns={
             "id": {"type": sa.BIGINT},
@@ -450,12 +482,13 @@ def test_array_float_vector(cratedb_target, helper):
     )
 
 
-def test_array_number(cratedb_target, helper):
+def test_array_number(cratedb_target):
     file_name = "array_number.singer"
     singer_file_to_target(file_name, cratedb_target)
     row = {"id": 1, "value": [42.42, 84.84, 23]}
-    helper.verify_data("array_number", 3, "id", row)
-    helper.verify_schema(
+    verify_data(cratedb_target, "array_number", 3, "id", row)
+    verify_schema(
+        cratedb_target,
         "array_number",
         check_columns={
             "id": {"type": sa.BIGINT},
@@ -464,12 +497,13 @@ def test_array_number(cratedb_target, helper):
     )
 
 
-def test_array_string(cratedb_target, helper):
+def test_array_string(cratedb_target):
     file_name = "array_string.singer"
     singer_file_to_target(file_name, cratedb_target)
     row = {"id": 1, "value": ["apple", "orange", "pear"]}
-    helper.verify_data("array_string", 4, "id", row)
-    helper.verify_schema(
+    verify_data(cratedb_target, "array_string", 4, "id", row)
+    verify_schema(
+        cratedb_target,
         "array_string",
         check_columns={
             "id": {"type": sa.BIGINT},
@@ -478,12 +512,13 @@ def test_array_string(cratedb_target, helper):
     )
 
 
-def test_array_timestamp(cratedb_target, helper):
+def test_array_timestamp(cratedb_target):
     file_name = "array_timestamp.singer"
     singer_file_to_target(file_name, cratedb_target)
     row = {"id": 1, "value": ["2023-12-13T01:15:02", "2023-12-13T01:16:02"]}
-    helper.verify_data("array_timestamp", 3, "id", row)
-    helper.verify_schema(
+    verify_data(cratedb_target, "array_timestamp", 3, "id", row)
+    verify_schema(
+        cratedb_target,
         "array_timestamp",
         check_columns={
             "id": {"type": sa.BIGINT},
@@ -492,7 +527,7 @@ def test_array_timestamp(cratedb_target, helper):
     )
 
 
-def test_object_mixed(cratedb_target, helper):
+def test_object_mixed(cratedb_target):
     file_name = "object_mixed.singer"
     singer_file_to_target(file_name, cratedb_target)
     row = {
@@ -509,8 +544,9 @@ def test_object_mixed(cratedb_target, helper):
             "nested_object": {"foo": "bar"},
         },
     }
-    helper.verify_data("object_mixed", 1, "id", row)
-    helper.verify_schema(
+    verify_data(cratedb_target, "object_mixed", 1, "id", row)
+    verify_schema(
+        cratedb_target,
         "object_mixed",
         check_columns={
             "id": {"type": sa.BIGINT},
@@ -519,7 +555,7 @@ def test_object_mixed(cratedb_target, helper):
     )
 
 
-def test_encoded_string_data(cratedb_target, helper):
+def test_encoded_string_data(cratedb_target):
     """
     We removed NUL characters from the original encoded_strings.singer as postgres doesn't allow them.
     https://www.postgresql.org/docs/current/functions-string.html#:~:text=chr(0)%20is%20disallowed%20because%20text%20data%20types%20cannot%20store%20that%20character.
@@ -534,11 +570,11 @@ def test_encoded_string_data(cratedb_target, helper):
     file_name = "encoded_strings.singer"
     singer_file_to_target(file_name, cratedb_target)
     row = {"id": 1, "info": "simple string 2837"}
-    helper.verify_data("test_strings", 11, "id", row)
+    verify_data(cratedb_target, "test_strings", 11, "id", row)
     row = {"id": 1, "info": {"name": "simple", "value": "simple string 2837"}}
-    helper.verify_data("test_strings_in_objects", 11, "id", row)
+    verify_data(cratedb_target, "test_strings_in_objects", 11, "id", row)
     row = {"id": 1, "strings": ["simple string", "απλή συμβολοσειρά", "简单的字串"]}
-    helper.verify_data("test_strings_in_arrays", 6, "id", row)
+    verify_data(cratedb_target, "test_strings_in_arrays", 6, "id", row)
 
 
 @pytest.mark.skip("Fails with: SQLParseException[Limit of total fields [1000] in index [melty.aapl] has been exceeded]")
@@ -628,7 +664,7 @@ def test_activate_version_hard_delete(cratedb_config):
     singer_file_to_target(file_name, pg_hard_delete_true)
     with engine.connect() as connection, connection.begin():
         result = connection.execute(sa.text(f"SELECT * FROM {full_table_name}"))
-        assert result.rowcount == 7
+        assert result.rowcount == 8
     with engine.connect() as connection, connection.begin():
         # Add a record like someone would if they weren't using the tap target combo
         result = connection.execute(
@@ -642,14 +678,14 @@ def test_activate_version_hard_delete(cratedb_config):
         connection.execute(sa.text(f"REFRESH TABLE {full_table_name}"))
     with engine.connect() as connection, connection.begin():
         result = connection.execute(sa.text(f"SELECT * FROM {full_table_name}"))
-        assert result.rowcount == 9
+        assert result.rowcount == 10
 
     singer_file_to_target(file_name, pg_hard_delete_true)
 
     # Should remove the 2 records we added manually
     with engine.connect() as connection, connection.begin():
         result = connection.execute(sa.text(f"SELECT * FROM {full_table_name}"))
-        assert result.rowcount == 7
+        assert result.rowcount == 8
 
 
 def test_activate_version_soft_delete(cratedb_target):

--- a/target_cratedb/tests/test_standard_target.py
+++ b/target_cratedb/tests/test_standard_target.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import io
 from contextlib import redirect_stdout
+from typing import Optional
 
 import pytest
 import sqlalchemy as sa
@@ -148,7 +149,7 @@ def singer_file_to_target(file_name, target) -> None:
 def verify_schema(
     target: TargetCrateDB,
     table_name: str,
-    check_columns: dict = None,
+    check_columns: Optional[dict] = None,
 ):
     """Checks whether the schema of a database table matches the provided column definitions.
 
@@ -407,9 +408,9 @@ def test_relational_data(cratedb_target):
         },
     ]
 
-    verify_data("test_users", 8, "id", users)
-    verify_data("test_locations", 5, "id", locations)
-    verify_data("test_user_in_location", 5, "id", user_in_location)
+    verify_data(cratedb_target, "test_users", 8, "id", users)
+    verify_data(cratedb_target, "test_locations", 5, "id", locations)
+    verify_data(cratedb_target, "test_user_in_location", 5, "id", user_in_location)
 
 
 def test_no_primary_keys(cratedb_target):


### PR DESCRIPTION
## Problem
The package used a non-GA dependency `git+https://github.com/singer-contrib/meltanolabs-target-postgres.git@pgvector` before, so a PyPI release wasn't possible.

## Solution
Let's use a GA version of the `meltanolabs-target-postgres` package.
