### PR TITLE
Types: Add support for `FLOAT_VECTOR`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Removed workaround for `_`-prefixed column names.
   The package now requires CrateDB 6.2 or higher.
 - Dependencies: Updated to vanilla meltanolabs-target-postgres 0.6
+- Types: Added support for `FLOAT_VECTOR`.
 
 ## 2023-12-08 v0.0.1
 - Make it work. It can run the canonical Meltano GitHub -> DB example.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,27 @@ way of how Meltano handles database updates. The reason is that the vanilla way
 does not satisfy all test cases, yet.
 
 
+## Vector Store Support
+
+In order to support CrateDB's vector store feature, i.e. its `FLOAT_VECTOR`
+data type, you will need to install `numpy`. It has been added to an "extra"
+of the Python package, called `vector`.
+
+When installing the package using pip, this would apply:
+```
+pip install 'meltano-target-cratedb[vector]'
+```
+
+When installing the package using the Meltano's project definition, this
+would probably be the right way to write it down, but it hasn't been verified
+yet.
+```yaml
+- name: target-cratedb
+  variant: cratedb
+  pip_url: meltano-target-cratedb[vector]
+```
+
+
 ## Development
 
 In order to work on this adapter dialect on behalf of a real pipeline definition,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,8 +92,11 @@ dependencies = [
   "cratedb-toolkit",
   "importlib-resources; python_version<'3.9'", # "meltanolabs-target-postgres==0.0.9",
   "meltanolabs-target-postgres>=0.6,<0.7",
-  "sqlalchemy-cratedb",
+  "sqlalchemy-cratedb[vector]",
   "verlib2<0.4",
+]
+optional-dependencies.all = [
+  "meltano-target-cratedb[vector]",
 ]
 optional-dependencies.develop = [
   "black<27",
@@ -113,6 +116,11 @@ optional-dependencies.test = [
   "pytest<10",
   "pytest-cov<8",
   "pytest-mock<4",
+]
+optional-dependencies.vector = [
+  "meltanolabs-target-postgres @ git+https://github.com/singer-contrib/meltanolabs-target-postgres.git@pgvector",
+  "numpy",
+  "sqlalchemy-cratedb[vector]",
 ]
 urls.changelog = "https://github.com/crate/meltano-target-cratedb/blob/main/CHANGES.md"
 urls.documentation = "https://github.com/crate/meltano-target-cratedb"

--- a/target_cratedb/connector.py
+++ b/target_cratedb/connector.py
@@ -11,7 +11,7 @@ from datetime import datetime
 import sqlalchemy as sa
 from singer_sdk import typing as th
 from singer_sdk.helpers._typing import is_array_type, is_boolean_type, is_integer_type, is_number_type, is_object_type
-from sqlalchemy_cratedb.type import ObjectType
+from sqlalchemy_cratedb.type import FloatVector, ObjectType
 from sqlalchemy_cratedb.type.array import _ObjectArray
 from sqlalchemy_cratedb.type.object import ObjectTypeImpl
 from target_postgres.connector import NOTYPE, PostgresConnector
@@ -134,6 +134,44 @@ class CrateDBConnector(PostgresConnector):
         if "object" in jsonschema_type["type"]:
             return ObjectType
         if "array" in jsonschema_type["type"]:
+            # Select between different kinds of `ARRAY` data types.
+            #
+            # This currently leverages an unspecified definition for the Singer SCHEMA,
+            # using the `additionalProperties` attribute to convey additional type
+            # information, agnostic of the target database.
+            #
+            # In this case, it is about telling different kinds of `ARRAY` types apart:
+            # Either it is a vanilla `ARRAY`, to be stored into a `jsonb[]` type, or,
+            # alternatively, it can be a "vector" kind `ARRAY` of floating point
+            # numbers, effectively what pgvector is storing in its `VECTOR` type.
+            #
+            # Still, `type: "vector"` is only a surrogate label here, because other
+            # database systems may use different types for implementing the same thing,
+            # and need to translate accordingly.
+            """
+            Schema override rule in `meltano.yml`:
+
+            type: "array"
+            items:
+              type: "number"
+            additionalProperties:
+              storage:
+                type: "vector"
+                dim: 4
+
+            Produced schema annotation in `catalog.json`:
+
+            {"type": "array",
+             "items": {"type": "number"},
+             "additionalProperties": {"storage": {"type": "vector", "dim": 4}}}
+            """
+            if "additionalProperties" in jsonschema_type and "storage" in jsonschema_type["additionalProperties"]:
+                storage_properties = jsonschema_type["additionalProperties"]["storage"]
+                if "type" in storage_properties and storage_properties["type"] == "vector":
+                    # On PostgreSQL/pgvector, use the corresponding type definition
+                    # from its SQLAlchemy dialect.
+                    return FloatVector(dimensions=storage_properties["dim"])
+
             # Discover/translate inner types.
             inner_type = resolve_array_inner_type(jsonschema_type)
             if inner_type is not None:
@@ -163,6 +201,7 @@ class CrateDBConnector(PostgresConnector):
         """
         precedence_order = [
             sa.ARRAY,
+            FloatVector,
             ObjectTypeImpl,
             sa.TEXT,
             sa.TIMESTAMP,
@@ -213,6 +252,8 @@ class CrateDBConnector(PostgresConnector):
             _len = int(getattr(sql_type, "length", 0) or 0)
 
             if isinstance(sql_type, _ObjectArray):
+                return 0, _len
+            if isinstance(sql_type, FloatVector):
                 return 0, _len
             if isinstance(sql_type, NOTYPE):
                 return 0, _len

--- a/target_cratedb/tests/test_standard_target.py
+++ b/target_cratedb/tests/test_standard_target.py
@@ -11,6 +11,7 @@ import pytest
 import sqlalchemy as sa
 from singer_sdk.exceptions import InvalidRecord, MissingKeyPropertiesError
 from singer_sdk.testing import sync_end_to_end
+from sqlalchemy_cratedb.type import FloatVector
 from sqlalchemy_cratedb.type.object import ObjectTypeImpl
 from tap_countries.tap import TapCountries
 from tap_fundamentals import Fundamentals
@@ -96,6 +97,7 @@ def initialize_database(cratedb_config):
     delete_table_names = [
         "melty.array_boolean",
         "melty.array_float",
+        "melty.array_float_vector",
         "melty.array_number",
         "melty.array_string",
         "melty.array_timestamp",
@@ -457,6 +459,26 @@ def test_array_boolean(cratedb_target):
         check_columns={
             "id": {"type": sa.BIGINT},
             "value": {"type": sa.ARRAY},
+        },
+    )
+
+
+@pytest.mark.skip("pgvector patch did not land in upstream target-postgres yet")
+@pytest.mark.skipif(not MELTANO_CRATEDB_STRATEGY_DIRECT, reason="Does not work in temptable/upsert mode")
+def test_array_float_vector(cratedb_target):
+    file_name = "array_float_vector.singer"
+    singer_file_to_target(file_name, cratedb_target)
+    row = {
+        "id": 1,
+        "value": [1.1, 2.1, 1.1, 1.3],
+    }
+    verify_data(cratedb_target, "array_float_vector", 3, "id", row)
+    verify_schema(
+        cratedb_target,
+        "array_float_vector",
+        check_columns={
+            "id": {"type": sa.BIGINT},
+            "value": {"type": FloatVector},
         },
     )
 


### PR DESCRIPTION
## About
Support CrateDB's vector store data type.

## References
- GH-5
