### PR TITLE
Use `SQLConnector.jsonschema_to_sql` to map schema types to SQL types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## In progress
 - Meltano: Started using `SQLConnector.jsonschema_to_sql` to map
   schema types to SQL types
+- Type mapping: Started to verify mapping `ARRAY(OBJECT)` works well
 
 ## 2026-01-23 v0.0.2
 - Added support for container types `ARRAY` and `OBJECT`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changelog for Meltano/Singer Target for CrateDB
 
 ## In progress
+- Meltano: Started using `SQLConnector.jsonschema_to_sql` to map
+  schema types to SQL types
 
 ## 2026-01-23 v0.0.2
 - Added support for container types `ARRAY` and `OBJECT`.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+# https://docs.codecov.io/docs/common-recipe-list
+# https://docs.codecov.io/docs/commit-status#patch-status
+
+coverage:
+  status:
+
+    project:
+      default:
+        target: 85%
+
+    patch:
+      default:
+        informational: true

--- a/target_cratedb/connector.py
+++ b/target_cratedb/connector.py
@@ -7,11 +7,10 @@ import typing as t
 from builtins import issubclass  # noqa: A004
 from contextlib import contextmanager
 from datetime import datetime
+from functools import cached_property
 
 import sqlalchemy as sa
-from singer_sdk import typing as th
-from singer_sdk.helpers._typing import is_array_type, is_boolean_type, is_integer_type, is_number_type, is_object_type
-from sqlalchemy_cratedb.type import ObjectType
+from singer_sdk.sql.connector import JSONSchemaToSQL
 from sqlalchemy_cratedb.type.array import _ObjectArray
 from sqlalchemy_cratedb.type.object import ObjectTypeImpl
 from target_postgres.connector import NOTYPE, PostgresConnector
@@ -67,8 +66,19 @@ class CrateDBConnector(PostgresConnector):
         if Version(cratedb_version) < Version("6.2"):
             raise ConnectionError("The connector requires CrateDB 6.2 or higher")
 
-    @staticmethod
-    def to_sql_type(jsonschema_type: dict) -> sa.types.TypeEngine:
+    @cached_property
+    def jsonschema_to_sql(self) -> JSONSchemaToSQL:
+        """
+        Return a JSONSchemaToSQL instance with custom type handling.
+
+        Note: Needs to be patched to supply handler for `ObjectTypeImpl`.
+        """
+        to_sql = super().jsonschema_to_sql
+        to_sql.register_sql_datatype_handler("integer", sa.BIGINT)
+        to_sql.register_type_handler("object", ObjectTypeImpl)
+        return to_sql
+
+    def to_sql_type(self, jsonschema_type: dict) -> sa.types.TypeEngine:
         """Return a JSON Schema representation of the provided type.
 
         Note: Needs to be patched to invoke other static methods on `CrateDBConnector`.
@@ -93,61 +103,36 @@ class CrateDBConnector(PostgresConnector):
                 json_type_array.append(jsonschema_type)
             elif isinstance(jsonschema_type["type"], list):
                 for entry in jsonschema_type["type"]:
-                    json_type_dict = {}
-                    json_type_dict["type"] = entry
+                    json_type_dict = {"type": entry}
                     if jsonschema_type.get("format", False):
                         json_type_dict["format"] = jsonschema_type["format"]
+                    if encoding := jsonschema_type.get("contentEncoding", False):
+                        json_type_dict["contentEncoding"] = encoding
+                    # Figure out array type, but only if there's a single type
+                    # (no array union types)
+                    if (
+                        "items" in jsonschema_type
+                        and "type" in jsonschema_type["items"]
+                        and isinstance(jsonschema_type["items"]["type"], str)
+                    ):
+                        json_type_dict["items"] = jsonschema_type["items"]["type"]
                     json_type_array.append(json_type_dict)
             else:
                 msg = "Invalid format for jsonschema type: not str or list."
                 raise RuntimeError(msg)
         elif jsonschema_type.get("anyOf", False):
-            for entry in jsonschema_type["anyOf"]:
-                json_type_array.append(entry)
+            json_type_array.extend(iter(jsonschema_type["anyOf"]))
         else:
             msg = "Neither type nor anyOf are present. Unable to determine type. " "Defaulting to string."
             return NOTYPE()
         sql_type_array = []
         for json_type in json_type_array:
-            picked_type = CrateDBConnector.pick_individual_type(jsonschema_type=json_type)
+            picked_type = self.pick_individual_type(jsonschema_type=json_type)
             if picked_type is not None:
                 sql_type_array.append(picked_type)
 
-        return CrateDBConnector.pick_best_sql_type(sql_type_array=sql_type_array)
-
-    @staticmethod
-    def pick_individual_type(jsonschema_type: dict):
-        """Select the correct sql type assuming jsonschema_type has only a single type.
-
-        Note: Needs to be patched to supply handlers for `object` and `array`.
-
-        Args:
-            jsonschema_type: A jsonschema_type array containing only a single type.
-
-        Returns:
-            An instance of the appropriate SQL type class based on jsonschema_type.
-        """
-        if "null" in jsonschema_type["type"]:
-            return None
-        if "integer" in jsonschema_type["type"]:
-            return sa.BIGINT()
-        if "object" in jsonschema_type["type"]:
-            return ObjectType
-        if "array" in jsonschema_type["type"]:
-            # Discover/translate inner types.
-            inner_type = resolve_array_inner_type(jsonschema_type)
-            if inner_type is not None:
-                return sa.ARRAY(inner_type)
-
-            # When type discovery fails, assume `TEXT`.
-            return sa.ARRAY(sa.TEXT())
-
-        if jsonschema_type.get("format") == "date-time":
-            return sa.TIMESTAMP()
-        individual_type = th.to_sql_type(jsonschema_type)
-        if isinstance(individual_type, sa.VARCHAR):
-            return sa.TEXT()
-        return individual_type
+        # NOTE: Adjustment for CrateDB.
+        return self.pick_best_sql_type(sql_type_array=sql_type_array)
 
     @staticmethod
     def pick_best_sql_type(sql_type_array: list):
@@ -163,6 +148,7 @@ class CrateDBConnector(PostgresConnector):
         """
         precedence_order = [
             sa.ARRAY,
+            # NOTE: Adjustment for CrateDB.
             ObjectTypeImpl,
             sa.TEXT,
             sa.TIMESTAMP,
@@ -274,18 +260,3 @@ class CrateDBConnector(PostgresConnector):
         Don't emit `CREATE SCHEMA` statements to CrateDB.
         """
         pass
-
-
-def resolve_array_inner_type(jsonschema_type: dict) -> t.Union[sa.types.TypeEngine, None]:
-    if "items" in jsonschema_type:
-        if is_boolean_type(jsonschema_type["items"]):
-            return sa.BOOLEAN()
-        if is_number_type(jsonschema_type["items"]):
-            return sa.FLOAT()
-        if is_integer_type(jsonschema_type["items"]):
-            return sa.BIGINT()
-        if is_object_type(jsonschema_type["items"]):
-            return ObjectType()
-        if is_array_type(jsonschema_type["items"]):
-            return resolve_array_inner_type(jsonschema_type["items"]["type"])
-    return None

--- a/target_cratedb/connector.py
+++ b/target_cratedb/connector.py
@@ -74,7 +74,7 @@ class CrateDBConnector(PostgresConnector):
         Note: Needs to be patched to supply handler for `ObjectTypeImpl`.
         """
         to_sql = super().jsonschema_to_sql
-        to_sql.register_sql_datatype_handler("integer", sa.BIGINT)
+        to_sql.register_type_handler("integer", sa.BIGINT)
         to_sql.register_type_handler("object", ObjectTypeImpl)
         return to_sql
 
@@ -110,12 +110,14 @@ class CrateDBConnector(PostgresConnector):
                         json_type_dict["contentEncoding"] = encoding
                     # Figure out array type, but only if there's a single type
                     # (no array union types)
-                    if (
-                        "items" in jsonschema_type
-                        and "type" in jsonschema_type["items"]
-                        and isinstance(jsonschema_type["items"]["type"], str)
-                    ):
-                        json_type_dict["items"] = jsonschema_type["items"]["type"]
+                    items = jsonschema_type.get("items") or {}
+                    item_type = items.get("type")
+                    if isinstance(item_type, str):
+                        json_type_dict["items"] = item_type
+                    elif isinstance(item_type, list):
+                        non_null = [t_ for t_ in item_type if t_ != "null"]
+                        if len(non_null) == 1:
+                            json_type_dict["items"] = non_null[0]
                     json_type_array.append(json_type_dict)
             else:
                 msg = "Invalid format for jsonschema type: not str or list."

--- a/target_cratedb/tests/data_files/array_object.singer
+++ b/target_cratedb/tests/data_files/array_object.singer
@@ -1,0 +1,3 @@
+{"type": "SCHEMA", "stream": "array_object", "key_properties": ["id"], "schema": {"required": ["id"], "type": "object", "properties": {"id": {"type": "integer"}, "value": {"type": "array", "items": {"type": "object"}}}}}
+{"type": "RECORD", "stream": "array_object", "record": {"id": 1, "value": [ {"name": "Hotzenplotz", "value": 42.42} ]}}
+{"type": "STATE", "value": {"array_object": 1}}

--- a/target_cratedb/tests/test_standard_target.py
+++ b/target_cratedb/tests/test_standard_target.py
@@ -174,8 +174,8 @@ def verify_schema(
                 raise ValueError(f"Invalid check_columns - missing definition for column: {column.name}") from ex
             if not isinstance(column.type, column_type_expected):
                 raise TypeError(
-                    f"Column '{column.name}' (with type '{column.type}') "
-                    f"does not match expected type: {column_type_expected}"
+                    f"Column '{column.name}' with SQL type {column.type} and Python type {type(column.type)} "
+                    f"does not match expected Python type {column_type_expected}."
                 )
     engine.dispose()
 

--- a/target_cratedb/tests/test_standard_target.py
+++ b/target_cratedb/tests/test_standard_target.py
@@ -11,6 +11,7 @@ import pytest
 import sqlalchemy as sa
 from singer_sdk.exceptions import InvalidRecord, MissingKeyPropertiesError
 from singer_sdk.testing import sync_end_to_end
+from sqlalchemy_cratedb.type.array import _ObjectArray
 from sqlalchemy_cratedb.type.object import ObjectTypeImpl
 from tap_countries.tap import TapCountries
 from tap_fundamentals import Fundamentals
@@ -97,6 +98,7 @@ def initialize_database(cratedb_config):
         "melty.array_boolean",
         "melty.array_float",
         "melty.array_number",
+        "melty.array_object",
         "melty.array_string",
         "melty.array_timestamp",
         "melty.commits",
@@ -472,6 +474,21 @@ def test_array_number(cratedb_target):
         check_columns={
             "id": {"type": sa.BIGINT},
             "value": {"type": sa.ARRAY},
+        },
+    )
+
+
+def test_array_object(cratedb_target):
+    file_name = "array_object.singer"
+    singer_file_to_target(file_name, cratedb_target)
+    row = {"id": 1, "value": [{"name": "Hotzenplotz", "value": 42.42}]}
+    verify_data(cratedb_target, "array_object", 1, "id", row)
+    verify_schema(
+        cratedb_target,
+        "array_object",
+        check_columns={
+            "id": {"type": sa.BIGINT},
+            "value": {"type": _ObjectArray},
         },
     )
 


### PR DESCRIPTION
## Problem
After CrateDB 6.4 will become a bit stricter when it comes to keep data type mapping upright around nested data, specifically in the area of ARRAY inner types, we found integration tests to be failing on CrateDB nightly.

## Solution
Thanks to the modern Meltano type mapper `JSONSchemaToSQL`, we have been able to satisfy integration tests by just removing significant portions of proprietary type mapping code. In this spirit, relevant improvements are certainly based on improvements to the Meltano SDK and the PostgreSQL target adapter implementation. Thank you @edgarrmondragon. 🙇 

## References
- https://github.com/crate/crate/pull/19212
- https://github.com/crate/cratedb-examples/issues/1541
- GH-93

/cc @joerg84, @seut 
