### PR TITLE
Fix `NameError: name 'RequestsCookieJar' is not defined`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ dependencies = [
   "cratedb-toolkit",
   "importlib-resources; python_version<'3.9'", # "meltanolabs-target-postgres==0.0.9",
   "meltanolabs-target-postgres>=0.6,<0.7",
+  "requests<2.34",
   "sqlalchemy-cratedb",
   "verlib2<0.4",
 ]


### PR DESCRIPTION
## Problem

CI started failing.

## Solution

Downgrade to `requests` 2.33.

## Details

```python
target_cratedb/tests/test_standard_target.py:203:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.venv/lib/python3.11/site-packages/singer_sdk/testing/legacy.py:255: in sync_end_to_end
    tap.sync_all()
.venv/lib/python3.11/site-packages/singer_sdk/tap_base.py:495: in sync_all
    stream.sync()
.venv/lib/python3.11/site-packages/singer_sdk/streams/core.py:1415: in sync
    for _ in self._sync_records(context=context):
.venv/lib/python3.11/site-packages/singer_sdk/streams/core.py:1283: in _sync_records
    for idx, record_result in enumerate(self.get_records(current_context)):
.venv/lib/python3.11/site-packages/singer_sdk/streams/rest.py:642: in get_records
    yield from self.request_records(context)
.venv/lib/python3.11/site-packages/singer_sdk/streams/rest.py:472: in request_records
    resp = decorated_request(prepared_request, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.11/site-packages/backoff/_sync.py:105: in retry
    ret = target(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.11/site-packages/singer_sdk/streams/rest.py:329: in _request
    response = self.requests_session.send(
.venv/lib/python3.11/site-packages/requests_cache/session.py:218: in send
    cached_response = self.cache.get_response(actions.cache_key)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.11/site-packages/requests_cache/backends/base.py:77: in get_response
    response = self.responses.get(key)
               ^^^^^^^^^^^^^^^^^^^^^^^
<frozen _collections_abc>:774: in get
    ???
.venv/lib/python3.11/site-packages/requests_cache/backends/filesystem.py:107: in __getitem__
    return self.deserialize(key, f.read())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.11/site-packages/requests_cache/backends/base.py:357: in deserialize
    obj = self.serializer.loads(value)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.11/site-packages/requests_cache/serializers/pipeline.py:61: in loads
    value = step(value)
            ^^^^^^^^^^^
/Users/amo/.local/share/uv/python/cpython-3.11.11-macos-x86_64-none/lib/python3.11/functools.py:946: in _method
    return method.__get__(obj, cls)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.11/site-packages/requests_cache/serializers/cattrs.py:83: in _
    return _encode_content(self.converter.structure(value, cl=CachedResponse))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.11/site-packages/cattrs/converters.py:591: in structure
    return self._structure_func.dispatch(cl)(obj, cl)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.11/site-packages/cattrs/dispatch.py:133: in dispatch_without_caching
    res = self._function_dispatch.dispatch(typ)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.11/site-packages/cattrs/dispatch.py:76: in dispatch
    return handler(typ)
           ^^^^^^^^^^^^
.venv/lib/python3.11/site-packages/cattrs/converters.py:1308: in gen_structure_attrs_fromdict
    resolve_types(origin or cl)
.venv/lib/python3.11/site-packages/attr/_funcs.py:487: in resolve_types
    hints = typing.get_type_hints(cls, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/amo/.local/share/uv/python/cpython-3.11.11-macos-x86_64-none/lib/python3.11/typing.py:2377: in get_type_hints
    value = _eval_type(value, base_globals, base_locals)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/amo/.local/share/uv/python/cpython-3.11.11-macos-x86_64-none/lib/python3.11/typing.py:395: in _eval_type
    return t._evaluate(globalns, localns, recursive_guard)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/amo/.local/share/uv/python/cpython-3.11.11-macos-x86_64-none/lib/python3.11/typing.py:905: in _evaluate
    eval(self.__forward_code__, globalns, localns),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   NameError: name 'RequestsCookieJar' is not defined

<string>:1: NameError
```

## References

- [CI run #25713056566](https://github.com/crate/meltano-target-cratedb/actions/runs/25713056566/job/75497152982#step:7:133)

## Q & A

Did you observe that problem as well, @edgarrmondragon?
