### PR TITLE
Update to meltanolabs-target-postgres 0.8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog for Meltano/Singer Target for CrateDB
 
 ## In progress
+- Updated to `meltanolabs-target-postgres` 0.8. Thanks, @edgarrmondragon.
 
 ## 2026-05-12 v0.2.0
 - Updated to `meltanolabs-target-postgres` 0.7. Thanks, @edgarrmondragon.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,8 +88,7 @@ dynamic = [
 dependencies = [
   "cratedb-toolkit",
   "importlib-resources; python_version<'3.9'", # "meltanolabs-target-postgres==0.0.9",
-  "meltanolabs-target-postgres>=0.7,<0.8",
-  "requests<2.34",
+  "meltanolabs-target-postgres>=0.8,<0.9",
   "sqlalchemy-cratedb",
   "verlib2<0.4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,8 +121,8 @@ scripts.target-cratedb = "target_cratedb.target:TargetCrateDB.cli"
 packages.find.namespaces = false
 
 [tool.uv]
-sources.meltano-tap-countries = { git = "https://github.com/meltano/sdk.git", subdirectory = "packages/meltano-tap-countries", rev = "v0.53" }
-sources.meltano-tap-fundamentals = { git = "https://github.com/meltano/sdk.git", subdirectory = "packages/meltano-tap-fundamentals", rev = "v0.53" }
+sources.meltano-tap-countries = { git = "https://github.com/meltano/sdk.git", subdirectory = "packages/meltano-tap-countries", rev = "main" }
+sources.meltano-tap-fundamentals = { git = "https://github.com/meltano/sdk.git", subdirectory = "packages/meltano-tap-fundamentals", rev = "main" }
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
## About
[meltanolabs-target-postgres](https://pypi.org/project/meltanolabs-target-postgres/) v0.8.0 was released 21 minutes ago. Thank you, @edgarrmondragon.

## References
- GH-101
- GH-102
- GH-104
